### PR TITLE
Feature Identity Service

### DIFF
--- a/ISPSSService.psm1
+++ b/ISPSSService.psm1
@@ -1,7 +1,5 @@
-
 $subdomainApiUrl = $null
 $headers = @{}
-
 
 function Get-Token {
     [CmdletBinding()]

--- a/ISPSSService.psm1
+++ b/ISPSSService.psm1
@@ -1,0 +1,146 @@
+
+$subdomainApiUrl = $null
+$headers = @{}
+
+
+function Get-Token {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$subdomain, 
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [PSCredential]$APICredentials,
+
+        [Parameter(Mandatory = $false)]
+        [string]$grant_type = "client_credentials"
+    )
+    
+    begin {
+        $username = $APICredentials.UserName
+        $password = $APICredentials.GetNetworkCredential().Password
+        $body=@{
+            client_id = $username
+            client_secret = $password
+            grant_type = $grant_type
+        }
+        $token_endpoint = "https://$($subdomain).cyberark.cloud/api/idadmin/oauth2/platformtoken"
+    }
+    
+    process {
+        try {
+            $response = Invoke-RestMethod -Uri $token_endpoint -Method Post -Body $body
+            $global:subdomainApiUrl = "https://$($subdomain).cyberark.cloud/api/idadmin"
+            $global:headers = @{"Authorization" = "Bearer $($response.access_token)"}
+            return $true
+        }
+        catch {
+            if($_.ErrorDetails.Message) {
+                Write-Error $_.ErrorDetails.Message
+            } else {
+                Write-Error $_
+            }
+        }
+    }
+}
+
+function Get-AuthProfiles {
+    [CmdletBinding()]
+    param (
+
+    )
+    
+    begin {                
+        $reqUrl = "$($global:subdomainApiUrl)/AuthProfile/GetProfileList"
+    }
+    
+    process {
+        $response = Invoke-RestMethod -Uri $reqUrl -Method Get -Headers $global:headers
+        return $response
+    }
+}
+
+function Get-AuthProfile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$ProfileUuid
+    )
+    
+    begin {
+        $reqUrl = "$($global:subdomainApiUrl)/AuthProfile/GetProfile?uuid=${ProfileUuid}"
+    }
+    
+    process {
+        $response = Invoke-RestMethod -Uri $reqUrl -Method Get -Headers $global:headers
+        return $response
+    }
+}
+
+function Get-PolicyLinks {
+    [CmdletBinding()]
+    param (
+  
+    )
+    
+    begin {
+        $reqUrl = "$($global:subdomainApiUrl)/Policy/GetNicePlinks"
+    }
+    
+    process {
+        $response = Invoke-RestMethod -Uri $reqUrl -Method Get -Headers $global:headers
+        return $response
+    }
+}
+
+function Set-AuthProfile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $false)]
+        [string]$profileName = "MFA for Users",
+
+        [Parameter(Mandatory = $false)]
+        [string]$body = '{
+            "settings": {
+               "Challenges": [
+                  "UP",
+                  "OTP,OATH,QR,U2F"
+               ],
+               "DurationInMinutes": 30,
+               "Name": "'+ $profileName +'" 
+            }
+         }'
+    )
+    
+    begin {
+        $reqUrl = "$($global:subdomainApiUrl)/AuthProfile/SaveProfile"
+    }
+    
+    process {        
+        $response = Invoke-RestMethod -Uri $reqUrl -Method Post -Headers $global:headers -ContentType 'application/json' -Body $body
+        return $response
+    }
+}
+
+function Set-PolicyBlock {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$PolicyBlock 
+    )
+    
+    begin {
+        $reqUrl = "$($global:subdomainApiUrl)/policy/savepolicyblock3"
+    }
+    
+    process {        
+        $response = Invoke-RestMethod -Uri $reqUrl -Method Post -Headers $global:headers -ContentType 'application/json' -Body $body
+    }
+    
+    end {
+        
+    }
+}
+Export-ModuleMember -Function *


### PR DESCRIPTION
## Summary of the PR
Added API module which can be invoked by controller script.

## Details of the PR
This module contains the following functions

- Get-Token which accepts the subdomain name and credentials. This function generates the API token and makes the token available for the module functions
- Get-AuthProfiles lists all Authn profiles from CyberArk Identity
- Get-AuthProfile returns a specific Authn profile details. This function accepts Uuid of the Authn Profile to return the details
- Get-PolicyLinks returns all the Policies from CyberArk Identity
- Set-AuthProfile saves a new Authn profile. It accepts a profile name (optional) and a JSON body (optional)
- Set-PolicyBlock save a new Policy. It accepts a JSON body with Policy settings

## What sort of testing was done
All functions except Set-PolicyBlock was tested locally